### PR TITLE
Fix check for end of instructions

### DIFF
--- a/src/compiler/vm.rs
+++ b/src/compiler/vm.rs
@@ -48,7 +48,7 @@ impl VirtualMachine {
         // Process instruction at the program counter until exception or finished.
         loop {
             // for instruction in code.instructions {
-            if self.program_counter > code.instructions.len() {
+            if self.program_counter >= code.instructions.len() {
                 break;
             }
 


### PR DESCRIPTION
Indexing is 0-based, so when the program counter is N, we've already finished.

This fixes an issue where it was panicking whenever it successfully reached the end of a script.